### PR TITLE
Fixes #3

### DIFF
--- a/src/Class/Runner.php
+++ b/src/Class/Runner.php
@@ -60,28 +60,25 @@ class Runner {
    * Get Status.
    */
   public function status() {
-    $command = 'ps -p ' . $this->pid;
-    exec($command, $op);
-    if (!isset($op[1])) {
-      return FALSE;
-    }
-    else {
-      return TRUE;
-    }
+    return self::statusByPid($this->pid);
   }
 
   /**
    * Get Status by PID.
    */
   public static function statusByPid($pid) {
+    // Check if the ps command is provided by BusyBox. BusyBox's ps does not
+    // have a -p option so check if the process exists using procfs instead.
+    $check_ps = 'exec 2>/dev/null; readlink "/bin/ps"';
+    $retval = exec($check_ps);
+    if ($retval && preg_match('/^.*\/busybox$/', $retval)) {
+      $command = 'test -h /proc/' . $pid . '/exe';
+      exec($command, $op, $rstat);
+      return $rstat === 0;
+    }
     $command = 'ps -p ' . $pid;
     exec($command, $op);
-    if (!isset($op[1])) {
-      return FALSE;
-    }
-    else {
-      return TRUE;
-    }
+    return isset($op[1]);
   }
 
   /**


### PR DESCRIPTION
Going to `/admin/config/advancedqueue/runner` and then clicking run causes this error in docker:

```
ps: unrecognized option: p
```

Trying to run ps in docker container:
```
/var/www/drupal # ps -p 1
ps: unrecognized option: p
BusyBox v1.34.1 (2021-11-23 00:57:35 UTC) multi-call binary.

Usage: ps [-o COL1,COL2=HEADER] [-T]

Show list of processes

        -o COL1,COL2=HEADER     Select columns for display
        -T                      Show threads
```

Isle-dc docker images are built with BusyBox (see https://github.com/Islandora-Devops/isle-buildkit/blob/main/README.md#design-considerations), which doesn't support the `-p` select by pid option. In the module, there are status checks done before running the Runner, and these status checkers exec `ps -p <pid>` which causes an error in BusyBox.

#### Proposed Solution:
Check if `/bin/ps` is a symlink to `/bin/busybox`.
* If yes, check if the file `/proc/<PID>/exe` exists to see if the process exists
* If not, use `ps -p <pid>`