### PR TITLE
refactor: remove phpcs ignore comments by correcting their logic

### DIFF
--- a/advancedqueue_runner.module
+++ b/advancedqueue_runner.module
@@ -5,8 +5,6 @@
  * Contains advancedqueue_runner.module.
  */
 
-// phpcs:disable Drupal.NamingConventions.ValidFunctionName.InvalidPrefix
-
 include __DIR__ . "/src/Class/Runner.php";
 use Drupal\advancedqueue_runner\Classes\Runner;
 use Drupal\Core\Logger\RfcLogLevel;
@@ -43,7 +41,7 @@ function advancedqueue_runner_theme() {
 /**
  * To resolve https://github.com/digitalutsc/advanced-queue-runner/issues/2.
  */
-function set_environment_home() {
+function advancedqueue_runner_set_environment_home() {
   // To resolve https://github.com/digitalutsc/advanced-queue-runner/issues/2
   if (empty(getenv('HOME'))) {
     if (!empty(posix_getpwuid(posix_getuid()))) {
@@ -68,7 +66,7 @@ function advancedqueue_runner_cron() {
       if (!Runner::statusByPid($pid)) {
 
         // Have to set home variable.
-        set_environment_home();
+        advancedqueue_runner_set_environment_home();
 
         // If no, restart the runner with existing set config,.
         $newProcess = new Runner('php ' . __DIR__ . '/src/Scripts/jobs.php');
@@ -80,7 +78,7 @@ function advancedqueue_runner_cron() {
           $config->save();
         }
         else {
-          drupal_log("Unable to restart the runner");
+          advancedqueue_runner_drupal_log("Unable to restart the runner");
         }
       }
     }
@@ -88,47 +86,14 @@ function advancedqueue_runner_cron() {
 }
 
 /**
- * Debug function: display any variable to error log.
- *
- * @param $thing
- */
-if (!function_exists('print_log')) {
-
-  /**
-   * Print log to apache log.
-   */
-  function print_log($thing) {
-    error_log(print_r($thing, TRUE), 0);
-  }
-
-}
-/**
- * Debug function: display any variable to current webpage.
- *
- * @param $thing
- */
-if (!function_exists('logging')) {
-
-  /**
-   * Print log to webpage.
-   */
-  function logging($thing) {
-    echo "<pre>";
-    print_r($thing);
-    echo "</pre>";
-  }
-
-}
-
-/**
  * Debug function: display any variable to drupal Reports Log messages.
  */
-if (!function_exists('drupal_log')) {
+if (!function_exists('advancedqueue_runner_drupal_log')) {
 
   /**
    * Print log in Recent Log messages.
    */
-  function drupal_log($msg, $type = "error") {
+  function advancedqueue_runner_drupal_log($msg, $type = "error") {
     switch ($type) {
       case "notice":
         \Drupal::logger(basename(__FILE__, '.module'))->notice($msg);

--- a/advancedqueue_runner.module
+++ b/advancedqueue_runner.module
@@ -7,7 +7,6 @@
 
 include __DIR__ . "/src/Class/Runner.php";
 use Drupal\advancedqueue_runner\Classes\Runner;
-use Drupal\Core\Logger\RfcLogLevel;
 use Drupal\Core\Routing\RouteMatchInterface;
 
 /**
@@ -78,59 +77,9 @@ function advancedqueue_runner_cron() {
           $config->save();
         }
         else {
-          advancedqueue_runner_drupal_log("Unable to restart the runner");
+          \Drupal::logger("advancedqueue_runner")->error("Unable to restart the runner");
         }
       }
     }
   }
-}
-
-/**
- * Debug function: display any variable to drupal Reports Log messages.
- */
-if (!function_exists('advancedqueue_runner_drupal_log')) {
-
-  /**
-   * Print log in Recent Log messages.
-   */
-  function advancedqueue_runner_drupal_log($msg, $type = "error") {
-    switch ($type) {
-      case "notice":
-        \Drupal::logger(basename(__FILE__, '.module'))->notice($msg);
-        break;
-
-      case "log":
-        \Drupal::logger(basename(__FILE__, '.module'))->log(RfcLogLevel::NOTICE, $msg);
-        break;
-
-      case "warning":
-        \Drupal::logger(basename(__FILE__, '.module'))->warning($msg);
-        break;
-
-      case "alert":
-        \Drupal::logger(basename(__FILE__, '.module'))->alert($msg);
-        break;
-
-      case "critical":
-        \Drupal::logger(basename(__FILE__, '.module'))->critical($msg);
-        break;
-
-      case "debug":
-        \Drupal::logger(basename(__FILE__, '.module'))->debug($msg);
-        break;
-
-      case "info":
-        \Drupal::logger(basename(__FILE__, '.module'))->info($msg);
-        break;
-
-      case "emergency":
-        \Drupal::logger(basename(__FILE__, '.module'))->emergency($msg);
-        break;
-
-      default:
-        \Drupal::logger(basename(__FILE__, '.module'))->error($msg);
-        break;
-    }
-  }
-
 }

--- a/advancedqueue_runner.services.yml
+++ b/advancedqueue_runner.services.yml
@@ -4,4 +4,4 @@ services:
     arguments: ['advancedqueue_runner']
   advancedqueue_runner.default:
     class: Drupal\advancedqueue_runner\DefaultService
-    arguments: []
+    arguments: ['@entity_type.manager', '@messenger']

--- a/src/DefaultService.php
+++ b/src/DefaultService.php
@@ -2,17 +2,45 @@
 
 namespace Drupal\advancedqueue_runner;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+
 /**
  * Class DefaultService definition.
  */
 class DefaultService implements DefaultServiceInterface {
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Constructs a new DefaultService object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(EntityTypeManagerInterface $entityTypeManager) {
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
    * Implements countJob().
    */
   public function countJob(String $queue) {
-    // phpcs:ignore -- \Drupal calls should be avoided in classes, use dependency injection instead
-    $entity = \Drupal::entityTypeManager()->getStorage('advancedqueue_queue')->load($queue);
+    $entity = $this->entityTypeManager->getStorage('advancedqueue_queue')->load($queue);
     $jobs = $entity->getBackend()->countJobs()['queued'];
     return $jobs;
   }

--- a/src/Form/RunnerConfigForm.php
+++ b/src/Form/RunnerConfigForm.php
@@ -215,7 +215,7 @@ class RunnerConfigForm extends ConfigFormBase {
     parent::submitForm($form, $form_state);
 
     // Ensure the HOME enviroment variable is set.
-    set_environment_home();
+    advancedqueue_runner_set_environment_home();
 
     // Get existing config.
     $configFactory = $this->configFactory->getEditable('advancedqueue_runner.settings');

--- a/src/Form/RunnerConfigForm.php
+++ b/src/Form/RunnerConfigForm.php
@@ -1,18 +1,56 @@
 <?php
 
-// phpcs:disable DrupalPractice.Objects.GlobalDrupal.GlobalDrupal
-
 namespace Drupal\advancedqueue_runner\Form;
 
 use Drupal\advancedqueue_runner\Classes\Runner;
 use Drupal\Component\Render\FormattableMarkup;
 use Drupal\Core\Form\ConfigFormBase;
 use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Messenger\MessengerInterface;
 
 /**
  * Class RunnerConfigForm definition.
  */
 class RunnerConfigForm extends ConfigFormBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The messenger service.
+   *
+   * @var \Drupal\Core\Messenger\MessengerInterface
+   */
+  protected $messenger;
+
+  /**
+   * Constructs a RunnerConfigForm object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Messenger\MessengerInterface $messenger
+   *   The messenger service.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, MessengerInterface $messenger) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->messenger = $messenger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('messenger')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -46,13 +84,6 @@ class RunnerConfigForm extends ConfigFormBase {
     $runnerID = $config->get('runner-pid');
     $default = "Run";
 
-    // phpcs:ignore -- Unused variable $modes.
-    $modes = [
-      'limit' => $this
-        ->t('Only run queue(s) if there is queued job(s)'),
-      'full' => $this
-        ->t('Always run the queue(s) no matter what.'),
-    ];
     /** @var string $queue_str */
     $queue_str = '';
     if ($config->get('queues') !== NULL) {
@@ -106,13 +137,12 @@ class RunnerConfigForm extends ConfigFormBase {
         // If not running, remove the PID.
         $config->set('runner-pid', NULL);
         $config->save();
-        // phpcs:ignore -- t() calls should be avoided in classes
-        \Drupal::messenger()->addMessage(t('Sorry, the Advanced Queue Runner is not currently running. Please refresh the page to start it again.'), 'error');
+        $this->messenger()->addMessage($this->t('Sorry, the Advanced Queue Runner is not currently running. Please refresh the page to start it again.'), 'error');
         return $form;
       }
     }
     else {
-      $queues = \Drupal::entityQuery('advancedqueue_queue')->execute();
+      $queues = $this->entityTypeManager->getStorage('advancedqueue_queue')->getQuery()->execute();
       foreach ($queues as $key => $value) {
         $queues[$key] = $value . " <a href='/admin/config/system/queues/jobs/$key' target='_blank'>&#9432;</a>";
       }
@@ -225,8 +255,7 @@ class RunnerConfigForm extends ConfigFormBase {
       $status = $process->status();
 
       if ($status) {
-        // phpcs:ignore -- t() calls should be avoided in classes
-        \Drupal::messenger()->addMessage(t('The Runner is now active.'));
+        $this->messenger()->addMessage($this->t('The Runner is now active.'));
         $configFactory->set('runner-pid', $my_pid);
       }
     }

--- a/src/Scripts/jobs.php
+++ b/src/Scripts/jobs.php
@@ -42,14 +42,14 @@ function drush_advancedqueue(string $command): void {
     $msg = "Error with" . $e->getMessage();
 
     // Log the message to Recent Log Message console.
-    drupal_log($msg);
+    advancedqueue_runner_drupal_log($msg);
   });
   $process->stderr->on('error', function (\Exception $e) use ($command) {
     // Log an error.
     $msg = "ReactPHP Eventloop - stderr Error with" . $e->getMessage();
 
     // Log the message to Recent Log Message console.
-    drupal_log($msg);
+    advancedqueue_runner_drupal_log($msg);
   });
 }
 
@@ -132,7 +132,7 @@ $loop->addPeriodicTimer($interval, function () use ($queues, $mode, $base_url, $
     
   }
   catch (\Exception $e) {
-    drupal_log($e->getMessage());
+    advancedqueue_runner_drupal_log($e->getMessage());
   }
 });
 $loop->run();

--- a/src/Scripts/jobs.php
+++ b/src/Scripts/jobs.php
@@ -42,14 +42,14 @@ function drush_advancedqueue(string $command): void {
     $msg = "Error with" . $e->getMessage();
 
     // Log the message to Recent Log Message console.
-    advancedqueue_runner_drupal_log($msg);
+    \Drupal::logger("advancedqueue_runner")->error($msg);
   });
   $process->stderr->on('error', function (\Exception $e) use ($command) {
     // Log an error.
     $msg = "ReactPHP Eventloop - stderr Error with" . $e->getMessage();
 
     // Log the message to Recent Log Message console.
-    advancedqueue_runner_drupal_log($msg);
+    \Drupal::logger("advancedqueue_runner")->error($msg);
   });
 }
 
@@ -132,7 +132,7 @@ $loop->addPeriodicTimer($interval, function () use ($queues, $mode, $base_url, $
     
   }
   catch (\Exception $e) {
-    advancedqueue_runner_drupal_log($e->getMessage());
+    \Drupal::logger("advancedqueue_runner")->error($e->getMessage());
   }
 });
 $loop->run();


### PR DESCRIPTION
# Description
This PR removes the phpcs ignore comments by implementing their logic.

# Changes
- Update function names in the module file to have module name as the prefix, and remove unused utility functions `print_log` and `logging`.
-  Add appropriate required services in the `services.yml` file.
- Refactor the code to use **Dependency Injection** as it is the preferred method for accessing and using services in Drupal 8+ and should be used whenever possible.
Reference: [Services and dependency injection in Drupal](https://www.drupal.org/docs/drupal-apis/services-and-dependency-injection/services-and-dependency-injection-in-drupal#:~:text=Dependency%20injection%20is%20the%20preferred%20method%20for%20accessing%20and%20using%20services%20in%20Drupal%208%2B%20and%20should%20be%20used%20whenever%20possible.)